### PR TITLE
move `types` condition to the front

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,13 +23,13 @@
   "module": "index.js",
   "exports": {
     ".": {
-      "node": {
-        "require": "./dist/index.cjs",
-        "import": "./node-index.js"
-      },
       "types": {
         "require": "./index.d.cts",
         "import": "./index.d.ts"
+      },
+      "node": {
+        "require": "./dist/index.cjs",
+        "import": "./node-index.js"
       },
       "default": "./index.js"
     }


### PR DESCRIPTION
I moved `types` condition to the front. `package.json#exports` are **order-sensitive** - they are always matched from the top to the bottom. When a match is found then it should be used and no further matching should occur. 

Right now, the current setup works in TypeScript but it's considered a bug and it should not be relied upon, see the thread and the comment [here](https://github.com/microsoft/TypeScript/issues/50762#issuecomment-1528318260). For that reason, I would like to fix all popular packages that misconfigured their `exports` this way so the bug can be fixed in TypeScript.
