### PR TITLE
Update typings

### DIFF
--- a/test/types/index.test-d.ts
+++ b/test/types/index.test-d.ts
@@ -5,6 +5,7 @@ const path = 'type-test-store'
 
 expectType<RootDatabase>(open(path, { compression: true }))
 expectType<RootDatabase>(open({ path, compression: true }))
+expectType<RootDatabase>(open(path, { encryptionKey: 'Use this key to encrypt the data' }))
 
 const defaultStore = open({ path, compression: true })
 expectType<boolean>(await defaultStore.put('foo', { bar: 'baz' }))


### PR DESCRIPTION
The `encryptionKey` property in the [db options](https://github.com/kriszyp/lmdb-js#db-options) didn't seem to exist at all in the typings (nor did `eventTurnBatching`) - this adds them.

While I was at it, I added the remaining option descriptions as they appear in the readme to the options typings - since some options had them and some didn't. If they were omitted for a reason, happy to remove them and just add the `encryptionKey` and `eventTurnBatching` properties.