### PR TITLE
Safer Atomic assignment on ARM

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lmdb",
   "author": "Kris Zyp",
-  "version": "3.0.13",
+  "version": "3.0.14",
   "description": "Simple, efficient, scalable, high-performance LMDB interface",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
On ARM processors, use a safer Atomic assignment to avoid memory reordering race condition with setting the flag/status of an instruction, #294