### PR TITLE
batch.clear() improvement

### DIFF
--- a/write.js
+++ b/write.js
@@ -1111,7 +1111,7 @@ class Batch extends Array {
 		this.push({ type: 'del', key });
 	}
 	clear() {
-		this.splice(0, this.length);
+		this.length = 0;
 	}
 	write(callback) {
 		return this.callback(this, callback);


### PR DESCRIPTION
Is there a specific reason to use `.splice(0, this.length)` instead of simply setting `length = 0`? If there's not the latter is faster...