### PR TITLE
Add iterator helpers to RangeIterable

### DIFF
--- a/test/index.test.js
+++ b/test/index.test.js
@@ -2018,6 +2018,33 @@ describe('lmdb-js', function () {
 			all.should.deep.equal([2, { error: 'Error: test' }, 6, 4, 5, 6]);
 			expect(finished).to.be.equal(1);
 		});
+		it('take', function () {
+			const ri = new RangeIterable([1, 2, 3, 4]);
+			ri.take(2).asArray.should.deep.equal([1, 2]);
+		});
+		it('drop', function () {
+			const ri = new RangeIterable([1, 2, 3, 4]);
+			ri.drop(2).asArray.should.deep.equal([3, 4]);
+		});
+		it('reduce', function () {
+			const ri = new RangeIterable([1, 2, 3, 4]);
+			ri.reduce((sum, value) => sum + value, 0).should.equal(10);
+		});
+		it('some', function () {
+			const ri = new RangeIterable([1, 2, 3, 4]);
+			ri.some((value) => value > 2).should.equal(true);
+			ri.some((value) => value > 4).should.equal(false);
+		});
+		it('every', function () {
+			const ri = new RangeIterable([1, 2, 3, 4]);
+			ri.every((value) => value > 2).should.equal(false);
+			ri.every((value) => value > 0).should.equal(true);
+		});
+		it('find', function () {
+			const ri = new RangeIterable([1, 2, 3, 4]);
+			ri.find((value) => value > 2).should.equal(3);
+			should.equal(ri.find((value) => value > 4), undefined);
+		})
 	});
 	describe('mixed keys', function () {
 		this.timeout(10000);

--- a/util/RangeIterable.js
+++ b/util/RangeIterable.js
@@ -427,5 +427,68 @@ export class RangeIterable {
 			if (index-- === 0) return entry;
 		}
 	}
+
+	take(limit) {
+		let iterator = (this.iterator = this.iterate());
+		let iterable = new RangeIterable();
+		iterable.iterate = function * () {
+			for (let i = 0; i < limit; i++) {
+				yield iterator.next().value;
+			}
+		}
+		return iterable
+	}
+
+	drop(limit) {
+		let iterator = (this.iterator = this.iterate());
+		let iterable = new RangeIterable();
+		iterable.iterate = function * () {
+			for (let i = 0; i < limit; i++) {
+				iterator.next();
+			}
+			let result;
+			while ((result = iterator.next()).done !== true) {
+				yield result.value;
+			}
+		}
+		return iterable;
+	}
+
+	reduce(reducer, initialValue) {
+		let result = initialValue;
+		let iterator = (this.iterator = this.iterate());
+		let iteratorResult;
+		while ((iteratorResult = iterator.next()).done !== true) {
+			result = reducer(result, iteratorResult.value)
+		}
+		return result;
+	}
+
+	some(callback) {
+		let iterator = (this.iterator = this.iterate());
+		let result;
+		while ((result = iterator.next()).done !== true) {
+			if (callback(result.value)) { return true }
+		}
+		return false
+	}
+
+	every(callback) {
+		let iterator = (this.iterator = this.iterate());
+		let result;
+		while ((result = iterator.next()).done !== true) {
+			if (!callback(result.value)) { return false }
+		}
+		return true
+	}
+
+	find(callback) {
+		let iterator = (this.iterator = this.iterate());
+		let result;
+		while ((result = iterator.next()).done !== true) {
+			if (callback(result.value)) { return result.value }
+		}
+		return undefined
+	}
 }
 RangeIterable.prototype.DONE = DONE;


### PR DESCRIPTION
Implements the Iterator Helpers as defined by https://github.com/tc39/proposal-iterator-helpers for the `RangeIterable` class. 