### PR TITLE
Store copy of default buffer to shared user buffer

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,13 +8,13 @@ concurrency:
 
 jobs:
   test:
-    name: Test on Node ${{ matrix.node }}
-    runs-on: ubuntu-latest
+    name: Test on Node.js ${{ matrix.node }} and ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        node: [16, 18]
-        # node: [16, 18, 20, 22]
+        node: [16, 18, 20, 22]
+        os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,26 +24,18 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
-      
-      - name: Install Python dependencies
-        if: matrix.os == 'macos-latest'
-        run: python -m pip install setuptools
-
-      - name: Install latest node-gyp
-        if: matrix.os == 'macos-latest'
-        run: npm i -g node-gyp
 
       - name: Install dependencies
         if: |
-          !(matrix.node == 22 && matrix.os == 'windows-latest')
+          !(matrix.node == 16 && matrix.os == 'macos-latest')
         run: npm install
 
       - name: Build
         if: |
-          !(matrix.node == 22 && matrix.os == 'windows-latest')
+          !(matrix.node == 16 && matrix.os == 'macos-latest')
         run: npm run build
 
       - name: Run tests
         if: |
-          !(matrix.node == 22 && matrix.os == 'windows-latest')
+          !(matrix.node == 16 && matrix.os == 'macos-latest')
         run: npm test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         node: [16, 18, 20, 22]
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
       - name: Checkout repository
@@ -26,10 +26,16 @@ jobs:
           node-version: ${{ matrix.node }}
 
       - name: Install dependencies
+        if: |
+          !((matrix.node == 16 && matrix.os == 'macos-latest') || (matrix.node == 22 && matrix.os == 'windows-latest'))
         run: npm install
 
       - name: Build
+        if: |
+          !((matrix.node == 16 && matrix.os == 'macos-latest') || (matrix.node == 22 && matrix.os == 'windows-latest'))
         run: npm run build
 
       - name: Run tests
+        if: |
+          !((matrix.node == 16 && matrix.os == 'macos-latest') || (matrix.node == 22 && matrix.os == 'windows-latest'))
         run: npm test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,5 +28,8 @@ jobs:
       - name: Install dependencies
         run: npm install
 
+      - name: Build
+        run: npm run build
+
       - name: Run tests
         run: npm test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,15 +27,15 @@ jobs:
 
       - name: Install dependencies
         if: |
-          !(matrix.node == 16 && matrix.os == 'macos-latest')
+          !(matrix.node == 16 && matrix.os == 'macos-latest') || (matrix.node == 22 && matrix.os == 'windows-latest'))
         run: npm install
 
       - name: Build
         if: |
-          !(matrix.node == 16 && matrix.os == 'macos-latest')
+          !(matrix.node == 16 && matrix.os == 'macos-latest') || (matrix.node == 22 && matrix.os == 'windows-latest'))
         run: npm run build
 
       - name: Run tests
         if: |
-          !(matrix.node == 16 && matrix.os == 'macos-latest')
+          !(matrix.node == 16 && matrix.os == 'macos-latest') || (matrix.node == 22 && matrix.os == 'windows-latest'))
         run: npm test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,18 +24,23 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
+      
+      - name: Install Python dependencies
+        if: matrix.os == 'macos-latest'
+        run: |
+          python -m pip install setuptools
 
       - name: Install dependencies
         if: |
-          !((matrix.node == 16 && matrix.os == 'macos-latest') || (matrix.node == 22 && matrix.os == 'windows-latest'))
+          !(matrix.node == 22 && matrix.os == 'windows-latest')
         run: npm install
 
       - name: Build
         if: |
-          !((matrix.node == 16 && matrix.os == 'macos-latest') || (matrix.node == 22 && matrix.os == 'windows-latest'))
+          !(matrix.node == 22 && matrix.os == 'windows-latest')
         run: npm run build
 
       - name: Run tests
         if: |
-          !((matrix.node == 16 && matrix.os == 'macos-latest') || (matrix.node == 22 && matrix.os == 'windows-latest'))
+          !(matrix.node == 22 && matrix.os == 'windows-latest')
         run: npm test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,8 +27,11 @@ jobs:
       
       - name: Install Python dependencies
         if: matrix.os == 'macos-latest'
-        run: |
-          python -m pip install setuptools
+        run: python -m pip install setuptools
+
+      - name: Install latest node-gyp
+        if: matrix.os == 'macos-latest'
+        run: npm i -g node-gyp
 
       - name: Install dependencies
         if: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,32 @@
+name: Tests
+
+on: [pull_request]
+
+concurrency:
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  test:
+    name: Test on Node ${{ matrix.node }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node: [16, 18]
+        # node: [16, 18, 20, 22]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run tests
+        run: npm test

--- a/read.js
+++ b/read.js
@@ -401,23 +401,17 @@ export function addReadMethods(
 					keySize = this.writeKey(id, keyBytes, 4);
 				}
 			};
-			let userSharedBuffers =
-				this._userSharedBuffers || (this._userSharedBuffers = new Map());
-			let sharedBuffer = userSharedBuffers.get(id.toString());
-			if (!sharedBuffer) {
+			setKeyBytes();
+			let sharedBuffer = getUserSharedBuffer(
+				env.address,
+				keySize,
+				defaultBuffer,
+				options?.callback,
+			);
+			sharedBuffer.notify = () => {
 				setKeyBytes();
-				sharedBuffer = getUserSharedBuffer(
-					env.address,
-					keySize,
-					defaultBuffer,
-					options?.callback,
-				);
-				userSharedBuffers.set(id.toString(), sharedBuffer);
-				sharedBuffer.notify = () => {
-					setKeyBytes();
-					return notifyUserCallbacks(env.address, keySize);
-				};
-			}
+				return notifyUserCallbacks(env.address, keySize);
+			};
 			return sharedBuffer;
 		},
 

--- a/src/lmdb-js.h
+++ b/src/lmdb-js.h
@@ -284,8 +284,8 @@ typedef struct callback_holder_t {
 } callback_holder_t;
 
 typedef struct user_buffer_t {
-	napi_env env;
-	napi_ref buffer_ref;
+	std::shared_ptr<char> data;
+	size_t size;
 	std::vector<napi_threadsafe_function> callbacks;
 } user_buffer_t;
 

--- a/src/lmdb-js.h
+++ b/src/lmdb-js.h
@@ -282,10 +282,13 @@ typedef struct callback_holder_t {
 	EnvWrap* ew;
 	std::vector<napi_threadsafe_function> callbacks;
 } callback_holder_t;
+
 typedef struct user_buffer_t {
-	MDB_val buffer;
+	napi_env env;
+	napi_ref buffer_ref;
 	std::vector<napi_threadsafe_function> callbacks;
 } user_buffer_t;
+
 class ExtendedEnv {
 public:
 	ExtendedEnv();
@@ -298,7 +301,7 @@ public:
 	pthread_mutex_t userBuffersLock;
 	uint64_t lastTime; // actually encoded as double
 	uint64_t previousTime; // actually encoded as double
-	MDB_val getUserSharedBuffer(std::string key, MDB_val default_buffer, napi_value func, bool has_callback, napi_env env, EnvWrap* ew);
+	napi_value getUserSharedBuffer(std::string key, napi_value default_buffer, napi_value func, bool has_callback, napi_env env, EnvWrap* ew);
 	bool notifyUserCallbacks(std::string key);
 	bool attemptLock(std::string key, napi_env env, napi_value func, bool has_callback, EnvWrap* ew);
 	bool unlock(std::string key, bool only_check);

--- a/src/lmdb-js.h
+++ b/src/lmdb-js.h
@@ -282,13 +282,10 @@ typedef struct callback_holder_t {
 	EnvWrap* ew;
 	std::vector<napi_threadsafe_function> callbacks;
 } callback_holder_t;
-
 typedef struct user_buffer_t {
-	std::shared_ptr<char> data;
-	size_t size;
+	MDB_val buffer;
 	std::vector<napi_threadsafe_function> callbacks;
 } user_buffer_t;
-
 class ExtendedEnv {
 public:
 	ExtendedEnv();

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -914,21 +914,21 @@ describe('lmdb-js', function () {
 				});
 			it('getUserSharedBuffer', function () {
 				let defaultIncrementer = new BigInt64Array(1);
-				defaultIncrementer[0] = 4n;
 				let incrementer = new BigInt64Array(
 					db.getUserSharedBuffer('incrementer-test', defaultIncrementer.buffer),
 				);
+				incrementer[0] = 4n;
 				should.equal(Atomics.add(incrementer, 0, 1n), 4n);
 				let secondDefaultIncrementer = new BigInt64Array(1); //should not get used
-				incrementer = new BigInt64Array( // should return same incrementer
+				let nextIncrementer = new BigInt64Array( // should return same incrementer
 					db.getUserSharedBuffer(
 						'incrementer-test',
 						secondDefaultIncrementer.buffer,
 					),
 				);
-				should.equal(defaultIncrementer[0], 5n);
-				should.equal(Atomics.add(incrementer, 0, 1n), 5n);
-				should.equal(defaultIncrementer[0], 6n);
+				should.equal(incrementer[0], 5n);
+				should.equal(Atomics.add(nextIncrementer, 0, 1n), 5n);
+				should.equal(incrementer[0], 6n);
 				should.equal(secondDefaultIncrementer[0], 0n);
 			});
 			it('getUserSharedBuffer with callbacks', async function () {

--- a/test/threads.cjs
+++ b/test/threads.cjs
@@ -1,95 +1,122 @@
 var assert = require('assert');
-const { Worker, isMainThread, parentPort, threadId } = require('worker_threads');
+const {
+	Worker,
+	isMainThread,
+	parentPort,
+	threadId,
+} = require('worker_threads');
 var path = require('path');
 var numCPUs = require('os').cpus().length;
+const { setFlagsFromString } = require('v8');
+const { runInNewContext } = require('vm');
+
+setFlagsFromString('--expose_gc');
+const gc = runInNewContext('gc');
 
 const { open } = require('../dist/index.cjs');
 const MAX_DB_SIZE = 256 * 1024 * 1024;
 if (isMainThread) {
-  var inspector = require('inspector')
-//  inspector.open(9331, null, true);debugger
+	var inspector = require('inspector');
+	//  inspector.open(9331, null, true);debugger
 
-  // The main thread
+	// The main thread
 
-  let db = open({
-    path: path.resolve(__dirname, './testdata'),
-    maxDbs: 10,
-    mapSize: MAX_DB_SIZE,
-    maxReaders: 126,
-    overlappingSync: true,
-  });
+	let db = open({
+		path: path.resolve(__dirname, './testdata'),
+		maxDbs: 10,
+		mapSize: MAX_DB_SIZE,
+		maxReaders: 126,
+		overlappingSync: true,
+	});
 
-  var workerCount = Math.min(numCPUs * 2, 20);
-  var value = {test: '48656c6c6f2c20776f726c6421'};
-  var str = 'this is supposed to be bigger than 16KB threshold for shared memory buffers';
-  for (let i = 0; i < 9; i++) {
-    str += str;
-  }
-  var bigValue = {test: str};
-  // This will start as many workers as there are CPUs available.
-  var workers = [];
-  for (var i = 0; i < workerCount; i++) {
-    var worker = new Worker(__filename);
-    workers.push(worker);
-  }
+	let incrementer = new BigInt64Array(1);
+	let incrementerBuffer = db.getUserSharedBuffer('test', incrementer.buffer);
+	incrementer = new BigInt64Array(incrementerBuffer);
+	incrementer[0] = 10000n;
 
-  var messages = [];
-  workers.forEach(function(worker) {
-    worker.on('message', function(msg) {
-      messages.push(msg);
-      // Once every worker has replied with a response for the value
-      // we can exit the test.
+	var workerCount = Math.min(numCPUs * 2, 20);
+	var value = { test: '48656c6c6f2c20776f726c6421' };
+	var str =
+		'this is supposed to be bigger than 16KB threshold for shared memory buffers';
+	for (let i = 0; i < 9; i++) {
+		str += str;
+	}
+	var bigValue = { test: str };
+	// This will start as many workers as there are CPUs available.
+	var workers = [];
+	for (var i = 0; i < workerCount; i++) {
+		var worker = new Worker(__filename);
+		workers.push(worker);
+	}
 
-      setTimeout(() => {
-        worker.terminate()
-      }, 100);
-      if (messages.length === workerCount) {
-        db.close();
-        for (var i = 0; i < messages.length; i ++) {
-          assert(messages[i] === value.toString('hex'));
-        }
-        console.log("done", threadId)
-        //setTimeout(() =>
-          //process.exit(0), 200);
-      }
-    });
-  });
+	var messages = [];
+	workers.forEach(function (worker) {
+		worker.on('message', function (msg) {
+			messages.push(msg);
+			// Once every worker has replied with a response for the value
+			// we can exit the test.
 
-  let last
-  for (var i = 0; i < workers.length; i++) {
-    last = db.put('key' + i, i % 2 === 1 ? bigValue : value);
-  }
+			setTimeout(() => {
+				worker.terminate();
+			}, 100);
+			if (messages.length === workerCount) {
+				db.close();
+				for (var i = 0; i < messages.length; i++) {
+					assert(messages[i] === value.toString('hex'));
+				}
+				assert(incrementer[0] === 10000n + BigInt(workerCount) * 10n);
+				console.log('done', threadId, incrementer[0]);
+				//setTimeout(() =>
+				//process.exit(0), 200);
+			}
+		});
+	});
 
-  last.then(() => {
-    for (var i = 0; i < workers.length; i++) {
-      var worker = workers[i];
-      worker.postMessage({key: 'key' + i});
-    };
-  });
+	let last;
+	for (var i = 0; i < workers.length; i++) {
+		last = db.put('key' + i, i % 2 === 1 ? bigValue : value);
+	}
 
+	last.then(() => {
+		for (var i = 0; i < workers.length; i++) {
+			var worker = workers[i];
+			worker.postMessage({ key: 'key' + i });
+		}
+	});
 } else {
-  // The worker process
-  let db = open({
-    path: path.resolve(__dirname, './testdata'),
-    maxDbs: 10,
-    mapSize: MAX_DB_SIZE,
-    maxReaders: 126,
-    overlappingSync: true,
-  });
+	// The worker process
+	let db = open({
+		path: path.resolve(__dirname, './testdata'),
+		maxDbs: 10,
+		mapSize: MAX_DB_SIZE,
+		maxReaders: 126,
+		overlappingSync: true,
+	});
 
+	parentPort.on('message', async function (msg) {
+		if (msg.key) {
+			for (let i = 0; i < 10; i++) {
+				let incrementer = new BigInt64Array(1);
+				incrementer[0] = 1n; // should be ignored
+				let incrementerBuffer = db.getUserSharedBuffer(
+					'test',
+					incrementer.buffer,
+				);
+				incrementer = new BigInt64Array(incrementerBuffer);
+				Atomics.add(incrementer, 0, 1n);
+				gc();
+				await new Promise((resolve) => setTimeout(resolve, 100));
+			}
 
-  parentPort.on('message', async function(msg) {
-    if (msg.key) {
-      var value = db.get(msg.key);
-      if (msg.key == 'key1' || msg.key == 'key3') {
-        await db.put(msg.key, 'updated');
-      }
-      if (value === null) {
-        parentPort.postMessage("");
-      } else {
-        parentPort.postMessage(value.toString('hex'));
-      }
-      
-    }
-  });
+			var value = db.get(msg.key);
+			if (msg.key == 'key1' || msg.key == 'key3') {
+				await db.put(msg.key, 'updated');
+			}
+			if (value === null) {
+				parentPort.postMessage('');
+			} else {
+				parentPort.postMessage(value.toString('hex'));
+			}
+		}
+	});
 }


### PR DESCRIPTION
Fixes a memory bug where underlying buffer data was no longer available causing the V8 garbage collected to crash Node.js.

```
node(98509,0x2087b0240) malloc: Heap corruption detected, free list is damaged at 0x600001968210
```

The culprit was due to at least three things:
1. The default buffer data was being directly referenced by multiple ArrayBuffer instances
2. The default buffer would be garbage collected as soon as `getUserSharedBuffer()` returned
3. There was insufficient reference counting to prevent V8 from garbage collecting values still in use

The solution is to create a _copy_ of the default buffer data and store it in the `user_buffer_t`. When the shared user buffer is requested, the smart pointer's reference count is incremented, and a new V8 ArrayBuffer value is returned.

Since the bug has been fixed, the changes to `read.js` from https://github.com/kriszyp/lmdb-js/commit/3a1864517efe402b71685b75ebb01436052b5983 have been reverted.