### PR TITLE
fix README example to use correct open() syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,7 @@ An LMDB database instance is created by using `open` export from the main module
 
 ```js
 import { open } from 'lmdb'; // or require
-let myDB = open({
-	path: 'my-db',
+let myDB = open('my-db', {
 	// any options go here, we can turn on compression like this:
 	compression: true,
 });


### PR DESCRIPTION
Updated the example in the README to pass the database path as the first argument to `open()`, instead of using an options object with a `path` property. This aligns with the correct API usage and prevents confusion for users.