### PR TITLE
Fix Deno cleanup-hook panics in lmdb-js env teardown

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "recompile": "node-gyp clean && node-gyp configure && node-gyp build",
     "recompile-v1": "node-gyp clean && set LMDB_DATA_V1=true&& node-gyp configure && set LMDB_DATA_V1=true&& node-gyp build",
     "test": "mocha test/**.test.js --expose-gc --recursive",
-    "deno-test": "deno run --allow-ffi --allow-write --allow-read --allow-env --allow-net --allow-import --allow-sys test/deno.ts",
+    "deno-test": "deno run --allow-ffi --allow-write --allow-read --allow-run --allow-env --allow-net --allow-import --allow-sys test/deno.ts",
     "test2": "mocha test/performance.js -u tdd",
     "test:types": "tsd",
     "benchmark": "node ./benchmark/index.js"

--- a/src/env.cpp
+++ b/src/env.cpp
@@ -48,11 +48,13 @@ env_tracking_t* EnvWrap::initTracking() {
 static napi_ref testRef;
 static napi_env testRefEnv;
 void EnvWrap::cleanupEnvWraps(void* data) {
-	if (openEnvWraps)
-		delete openEnvWraps;
-	else
-		fprintf(stderr, "How do we end up cleanup env wraps that don't exist?\n");
-	openEnvWraps = nullptr;
+	// The cleanup-hook arg is the identity of the bookkeeping allocation for
+	// this thread's open env list.
+	auto* envWraps = (std::vector<EnvWrap*>*) data;
+	delete envWraps;
+	if (openEnvWraps == envWraps) {
+		openEnvWraps = nullptr;
+	}
 }
 EnvWrap::EnvWrap(const CallbackInfo& info) : ObjectWrap<EnvWrap>(info) {
 	int rc;
@@ -70,6 +72,7 @@ EnvWrap::EnvWrap(const CallbackInfo& info) : ObjectWrap<EnvWrap>(info) {
 	this->writeWorker = nullptr;
 	this->readTxnRenewed = false;
     this->hasWrites = false;
+	this->cleanupHookRegistered = false;
 	this->lastReaderCheck = 0;
 	this->writingLock = new pthread_mutex_t;
 	this->writingCond = new pthread_cond_t;
@@ -246,7 +249,9 @@ static int encfunc(const MDB_val* src, MDB_val* dst, const MDB_val* key, int enc
 #endif
 
 void cleanup(void* data) {
-	((EnvWrap*) data)->closeEnv();
+	EnvWrap* envWrap = (EnvWrap*) data;
+	envWrap->cleanupHookRegistered = false;
+	envWrap->closeEnv();
 }
 
 Napi::Value EnvWrap::open(const CallbackInfo& info) {
@@ -323,7 +328,10 @@ Napi::Value EnvWrap::open(const CallbackInfo& info) {
 	//delete[] pathBytes;
 	if (rc != 0)
 		return throwLmdbError(info.Env(), rc);
-	napi_add_env_cleanup_hook(napiEnv, cleanup, this);
+	if (!cleanupHookRegistered) {
+		napi_add_env_cleanup_hook(napiEnv, cleanup, this);
+		cleanupHookRegistered = true;
+	}
 	return info.Env().Undefined();
 }
 int EnvWrap::openEnv(int flags, int jsFlags, const char* path, char* keyBuffer, Compression* compression, int maxDbs,
@@ -403,7 +411,9 @@ int EnvWrap::openEnv(int flags, int jsFlags, const char* path, char* keyBuffer, 
 		) {
 		if (!openEnvWraps) {
 			openEnvWraps = new std::vector<EnvWrap*>;
-			napi_add_env_cleanup_hook(napiEnv, cleanupEnvWraps, nullptr);
+			// Register this exact vector pointer so repeated hook registrations use
+			// distinct (fun, arg) pairs per allocation.
+			napi_add_env_cleanup_hook(napiEnv, cleanupEnvWraps, openEnvWraps);
 		}
 		openEnvWraps->push_back(this);
 	}
@@ -727,7 +737,10 @@ void EnvWrap::closeEnv(bool hasLock) {
 			++ewRef;
 		}
 	}
-	napi_remove_env_cleanup_hook(napiEnv, cleanup, this);
+	if (cleanupHookRegistered) {
+		cleanupHookRegistered = false;
+		napi_remove_env_cleanup_hook(napiEnv, cleanup, this);
+	}
 	cleanupStrayTxns();
 	if (!hasLock)
 		pthread_mutex_lock(envTracking->envsLock);
@@ -1383,4 +1396,3 @@ void EnvWrap::setupExports(Napi::Env env, Object exports) {
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-

--- a/src/lmdb-js.h
+++ b/src/lmdb-js.h
@@ -315,6 +315,8 @@ private:
 	std::vector<TxnWrap*> readTxns;
 	static env_tracking_t* initTracking();
 	napi_env napiEnv;
+	// Track whether this EnvWrap currently owns a registered env cleanup hook.
+	bool cleanupHookRegistered;
 	// compression settings and space
 	Compression *compression;
 	static thread_local std::vector<EnvWrap*>* openEnvWraps;
@@ -325,6 +327,7 @@ private:
 	static void cleanupEnvWraps(void* data);
 
 	friend class TxnWrap;
+	friend void cleanup(void* data);
 	friend class DbiWrap;
 
 public:

--- a/test/deno-cleanup-hook-exit.ts
+++ b/test/deno-cleanup-hook-exit.ts
@@ -1,0 +1,35 @@
+import { open } from 'npm:lmdb';
+
+try {
+	Deno.removeSync('test/testdata-cleanup-hook', { recursive: true });
+} catch (error) {
+	if (error.name != 'NotFound') throw error;
+}
+
+// This child process intentionally mixes:
+// - one env that is explicitly closed before process exit
+// - one env left open until Deno tears the environment down
+// - one delete-on-close env created through open()
+//
+// That combination exercises both new cleanup-hook fixes:
+// - the per-EnvWrap cleanup(this) registration/removal balance
+// - the openEnvWraps bookkeeping hook that now registers with a unique arg
+const explicitlyClosed = open('test/testdata-cleanup-hook/explicit', {
+	name: 'explicit-close',
+	useVersions: true,
+	overlappingSync: true,
+});
+const exitClosed = open('test/testdata-cleanup-hook/exit', {
+	name: 'exit-close',
+	useVersions: true,
+	overlappingSync: true,
+});
+const deleteOnClose = open();
+
+await explicitlyClosed.put('key', 'value');
+await exitClosed.put('key', 'value');
+await deleteOnClose.put('key', 'value');
+
+// This explicit close used to be one of the teardown paths that could race
+// against env cleanup and trigger "remove cleanup hook which was not registered".
+await explicitlyClosed.close();

--- a/test/deno.sh
+++ b/test/deno.sh
@@ -1,1 +1,1 @@
-deno run --reload --unstable --allow-env --allow-read --allow-write --allow-ffi test/deno.ts
+deno run --reload --unstable --allow-env --allow-read --allow-write --allow-run --allow-ffi test/deno.ts

--- a/test/deno.ts
+++ b/test/deno.ts
@@ -288,6 +288,41 @@ test('async transactions with async callbacks', async function () {
 		assert.equal(error.message, 'test2');
 	}
 });
+test('cleanup-hook lifecycle on exit', async function () {
+	// Run this in a child Deno process so the env cleanup hooks actually fire
+	// during process teardown. Mostly exercises in-process open/close behavior, not environment shutdown.
+	//
+	// Use `deno` CLI name here to match the repo's existing subprocess style,
+	// similar to the Node thread tests that spawn `node` against a sibling test file.
+	const command = new Deno.Command('deno', {
+		args: [
+			'run',
+			'--allow-ffi',
+			'--allow-write',
+			'--allow-read',
+			'--allow-env',
+			'--allow-import',
+			'--allow-sys',
+			'test/deno-cleanup-hook-exit.ts',
+		],
+		stdout: 'piped',
+		stderr: 'piped',
+	});
+	const { code, stdout, stderr } = await command.output();
+	const stdoutText = new TextDecoder().decode(stdout);
+	const stderrText = new TextDecoder().decode(stderr);
+
+	assert.equal(
+		code,
+		0,
+		`child exit failed\nstdout:\n${stdoutText}\nstderr:\n${stderrText}`,
+	);
+	// These substrings match the Deno panics we were fixing:
+	// - duplicate registration of cleanupEnvWraps with the same (fun, arg)
+	// - removal of cleanup(this) after that hook was no longer registered
+	assert.notInclude(stderrText, 'cleanup hook');
+	assert.notInclude(stderrText, 'panic');
+});
 function expand(str: string): string {
 	str = '(' + str + ')';
 	str = str + str;


### PR DESCRIPTION
This fixes Deno teardown panics in lmdb-js by making the addon’s env cleanup-hook lifecycle obey the Node-API contract.

What was wrong:
- cleanupEnvWraps was registered multiple times with the same (fun, arg) pair by using nullptr as the hook arg.
- cleanup(this) could be removed during teardown even when that hook was no longer registered.

Under Deno, those showed up as hard panics during env shutdown:
- duplicate cleanup-hook registration
- removing a cleanup hook that was not registered

What changed:
- cleanupEnvWraps now registers with the allocated openEnvWraps pointer as its hook arg and cleans up that exact allocation.
- EnvWrap now tracks whether its per-instance cleanup hook is currently registered, so add/remove stays balanced across explicit close, env cleanup, and destructor paths.
- Added a Deno regression that exercises mixed explicit-close and process-exit teardown.

Why this fix:
- lmdb-js already has multiple teardown paths by design.
- The right fix is to make bookkeeping paths contract-safe and non-duplicative under Node-API.