### PR TITLE
Release orphaned read snapshot when only renewing cursors remain

### DIFF
--- a/read.js
+++ b/read.js
@@ -590,6 +590,10 @@ export function addReadMethods(
 						if (snapshot === false) {
 							cursorRenewId = renewId; // use shared read transaction
 							txn.renewingRefCount = (txn.renewingRefCount || 0) + 1; // need to know how many are renewing cursors
+							// Track renewing cursors so that if this txn is orphaned (notCurrent) and its
+							// non-renewing refs later drain, we can release the snapshot instead of letting
+							// these cursors pin it (they don't need a stable snapshot). See Txn.done.
+							(txn.renewingCursors || (txn.renewingCursors = new Set())).add(cursor);
 						}
 					} catch (error) {
 						if (cursor) {
@@ -694,7 +698,10 @@ export function addReadMethods(
 				function finishCursor() {
 					if (!cursor || txn.isDone) return;
 					if (iterable.onDone) iterable.onDone();
-					if (cursorRenewId) txn.renewingRefCount--;
+					if (cursorRenewId) {
+						txn.renewingRefCount--;
+						txn.renewingCursors?.delete(cursor);
+					}
 					if (txn.refCount <= 1 && txn.notCurrent) {
 						cursor.close(); // this must be closed before the transaction is aborted or it can cause a
 						// segmentation fault
@@ -1084,6 +1091,22 @@ export function makeReusableBuffer(size) {
 Txn.prototype.done = function () {
 	this.refCount--;
 	if (this.refCount === 0 && this.notCurrent) {
+		this.abort();
+		this.isDone = true;
+	} else if (
+		this.notCurrent &&
+		!this.isDone &&
+		this.refCount > 0 &&
+		this.refCount === (this.renewingRefCount || 0)
+	) {
+		// The only remaining refs on this orphaned snapshot are renewing (snapshot:false)
+		// cursors, which don't need a stable snapshot. Release it now rather than letting
+		// them pin it until they next iterate (they may be suspended across an await).
+		// Close the cursors first — aborting a txn with attached open cursors is unsafe —
+		// then abort; their iterators re-acquire on the current read txn via the txn.isDone
+		// reposition path in the range iterator.
+		for (const cursor of this.renewingCursors) cursor.close();
+		this.renewingCursors.clear();
 		this.abort();
 		this.isDone = true;
 	} else if (this.refCount < 0)

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -2076,6 +2076,33 @@ describe('lmdb-js', function () {
 			await lastPromise;
 		});
 	});
+	describe('Renewing cursor snapshot release', function () {
+		it('releases an orphaned read snapshot once only renewing cursors remain', async function () {
+			let db = open({ path: path.join(testDirPath, 'renewing-release'), compression: false });
+			const N = 12;
+			for (let i = 0; i < N; i++) await db.put(`k${String(i).padStart(2, '0')}`, i);
+			await db.flushed;
+			// A non-renewing pin on the current shared read transaction (and a handle to it).
+			let txn = db.useReadTransaction();
+			// A snapshot:false (renewing) iterator; advancing it once attaches a renewing cursor to
+			// that same shared read transaction (refCount = pin + cursor, renewingRefCount = cursor).
+			let iterator = db.getRange({ snapshot: false })[Symbol.iterator]();
+			let first = iterator.next();
+			// Let resetReadTxn fire: refCount - renewingRefCount > 0, so the txn is orphaned.
+			await new Promise((resolve) => setTimeout(resolve, 20));
+			txn.notCurrent.should.equal(true);
+			// Release the non-renewing pin. Only the renewing cursor remains, which does not need a
+			// stable snapshot, so it must be released now rather than pinned until the (possibly
+			// suspended) iterator next iterates.
+			txn.done();
+			txn.isDone.should.equal(true);
+			// The renewing iterator must still reposition onto the current txn and read every entry.
+			let got = first.done ? [] : [first.value.key];
+			for (let r = iterator.next(); !r.done; r = iterator.next()) got.push(r.value.key);
+			got.should.deep.equal(Array.from({ length: N }, (_, i) => `k${String(i).padStart(2, '0')}`));
+			await db.close();
+		});
+	});
 	if (version.patch >= 90) {
 		describe('Threads', function () {
 			this.timeout(1000000);


### PR DESCRIPTION
## Problem

A `snapshot: false` range cursor uses the shared, renewable read transaction and is meant *not* to pin a read snapshot during iteration — on each `next()` it repositions onto the current read transaction (`resetReadTxn` resets the shared txn between iterations).

But that shared read transaction is also used by **non-renewing** readers (a plain `get`, a `useReadTransaction()` pin, a `snapshot: true` cursor). When a renewing cursor coexists with a non-renewing ref at a reset tick, `resetReadTxn` takes the **orphan** branch (`refCount - renewingRefCount > 0`): it marks the txn `notCurrent` and keeps it alive until `refCount` reaches 0, rather than resetting it.

If the renewing cursor's iterator is then **suspended between `next()` calls** — e.g. `for (const x of db.getRange({ snapshot: false })) { await something(x) }` where `something` stalls — it never repositions, so it pins the orphaned snapshot for the whole suspension. The non-renewing ref drains quickly, but the renewing cursor's ref keeps the orphaned snapshot's `refCount` above 0 indefinitely. A pinned read snapshot blocks free-page reclamation, so the data file grows. (Surfaced via a downstream replication disk-growth issue where an audit-log reader awaited slow per-record network sends — HarperFast/harperdb#3127, mitigation #3128.)

## Fix

Track renewing (`snapshot: false`) cursors on their `Txn`. In `Txn.prototype.done`, after decrementing `refCount`, if the txn is orphaned (`notCurrent`) and its remaining refs are all renewing cursors (`refCount === renewingRefCount`), the snapshot is no longer needed by anyone requiring stability — so close those cursors (required *before* aborting; aborting a txn with attached open cursors is unsafe) and abort the txn, releasing the snapshot. Suspended iterators re-acquire on the current read transaction via the existing `txn.isDone` reposition path in the range iterator's `next()`.

This complements the existing per-`next()` reposition, which already releases the orphaned snapshot for a *continuously* iterating cursor. It adds release at the other end — when the non-renewing refs that forced the orphan drain — so a suspended/stalled iterator no longer pins the snapshot.

## Why `refCount === renewingRefCount` is the right condition

`refCount` is incremented by every reader (cursors, `useReadTransaction` pins, `getSharedBinary`); `renewingRefCount` only by `snapshot: false` cursors. Equality therefore means the only remaining holders are renewing cursors. The `notCurrent` guard ensures the branch never fires on a live (current) transaction.

## Testing

- New regression test (`Renewing cursor snapshot release`): reproduces the orphan + drain and asserts the snapshot is released (`txn.isDone`) and the renewing iterator still reads every entry after repositioning. On master the orphaned txn stays pinned; with the fix it is released.
- Full suite passes (**368 passing**), including the multi-threaded read and read/write transaction worker tests — no concurrency regression.

🤖 Implemented with Claude (Opus 4.7); cross-model reviewed.
