### PR TITLE
Release orphaned read snapshot in resetReadTxn when only renewing cursors remain

### DIFF
--- a/read.js
+++ b/read.js
@@ -1067,6 +1067,17 @@ export function addReadMethods(
 				readTxn.notCurrent = true;
 				lastReadTxnRef = new WeakRef(readTxn);
 				readTxn = null;
+			} else if (readTxn.renewingRefCount > 0 && !readTxn.isDone) {
+				// Only renewing (snapshot:false) cursors remain attached. Because resetReadTxn runs on
+				// a setTimeout(0) macrotask, a renewing cursor present here is one whose iterator is
+				// suspended across the tick (a synchronous scan can't hold a cursor across this reset).
+				// Rather than resetTxn-in-place and leave those cursors renewing against the reset txn,
+				// release the snapshot the same way Txn.done does for orphaned txns, so the suspended
+				// iterators cleanly reposition on a fresh read txn via the txn.isDone path. This is the
+				// sibling of the orphaned-snapshot release for the reset-in-place path.
+				readTxn.notCurrent = true;
+				readTxn.releaseToRenewingCursors();
+				readTxn = null;
 			} else if (readTxn.address && !readTxn.isDone) {
 				resetTxn(readTxn.address);
 			} else {
@@ -1102,15 +1113,22 @@ Txn.prototype.done = function () {
 		// The only remaining refs on this orphaned snapshot are renewing (snapshot:false)
 		// cursors, which don't need a stable snapshot. Release it now rather than letting
 		// them pin it until they next iterate (they may be suspended across an await).
-		// Close the cursors first — aborting a txn with attached open cursors is unsafe —
-		// then abort; their iterators re-acquire on the current read txn via the txn.isDone
-		// reposition path in the range iterator.
-		for (const cursor of this.renewingCursors) cursor.close();
-		this.renewingCursors.clear();
-		this.abort();
-		this.isDone = true;
+		this.releaseToRenewingCursors();
 	} else if (this.refCount < 0)
 		throw new Error('Can not finish a transaction more times than it was used');
+};
+// Release the read snapshot held by an orphaned/reset txn whose only attached refs are renewing
+// (snapshot:false) cursors. Close those cursors first — aborting a txn with attached open cursors
+// is unsafe (segfault) — then abort, freeing the snapshot. Suspended iterators re-acquire on the
+// current read txn via the txn.isDone reposition path in the range iterator. Shared by Txn.done
+// (orphaned-then-drained path) and resetReadTxn (reset-while-renewing-cursors-attached path).
+Txn.prototype.releaseToRenewingCursors = function () {
+	if (this.renewingCursors) {
+		for (const cursor of this.renewingCursors) cursor.close();
+		this.renewingCursors.clear();
+	}
+	this.abort();
+	this.isDone = true;
 };
 Txn.prototype.use = function () {
 	this.refCount = (this.refCount || 0) + 1;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -2102,6 +2102,32 @@ describe('lmdb-js', function () {
 			got.should.deep.equal(Array.from({ length: N }, (_, i) => `k${String(i).padStart(2, '0')}`));
 			await db.close();
 		});
+		it('releases the read snapshot when a renewing iterator is suspended across a reset (no other refs)', async function () {
+			let db = open({ path: path.join(testDirPath, 'renewing-reset'), compression: false });
+			const N = 12;
+			for (let i = 0; i < N; i++) await db.put(`k${String(i).padStart(2, '0')}`, i);
+			await db.flushed;
+			// A snapshot:false (renewing) iterator with NO other ref on the shared read txn. Advancing
+			// it once attaches a renewing cursor (refCount === renewingRefCount === 1). This is the
+			// reset-in-place path of resetReadTxn — the sibling of the orphaned-snapshot release above.
+			let iterator = db.getRange({ snapshot: false })[Symbol.iterator]();
+			let first = iterator.next();
+			// Suspend across a resetReadTxn tick. With the fix the txn is released (cursors closed +
+			// aborted) rather than reset in place under the still-attached suspended cursor.
+			await new Promise((resolve) => setTimeout(resolve, 20));
+			// Mutate + flush after the reset so the old snapshot's pages would be reclaimed; a stranded
+			// cursor reading them would fault. The iterator must reposition onto the current txn.
+			for (let i = 0; i < N; i++) await db.put(`k${String(i).padStart(2, '0')}`, i + 100);
+			await db.flushed;
+			let got = first.done ? [] : [first.value.key];
+			for (let r = iterator.next(); !r.done; r = iterator.next()) got.push(r.value.key);
+			// Repositioning may legitimately re-yield the first key on the new snapshot; assert coverage
+			// rather than exact length, and assert no key was lost or corrupted.
+			let expected = Array.from({ length: N }, (_, i) => `k${String(i).padStart(2, '0')}`);
+			for (let key of expected) got.should.include(key);
+			got.every((k) => expected.includes(k)).should.equal(true);
+			await db.close();
+		});
 	});
 	if (version.patch >= 90) {
 		describe('Threads', function () {


### PR DESCRIPTION
## Summary

Follow-up to #357. #357 closed the orphaned read-snapshot use-after-free for **one** of two twin code paths — the case in `Txn.done` where a `notCurrent` txn's non-renewing refs drain, leaving only renewing (`snapshot: false`) cursors. It did **not** touch the sibling path: `resetReadTxn`'s `resetTxn`-in-place branch, which fires when only renewing cursors are attached to the shared read transaction.

`resetReadTxn` runs on a `setTimeout(0)` macrotask, so any renewing cursor still attached when it fires is one whose iterator is **suspended across the tick** — a synchronous scan can't hold a cursor across this reset. That is exactly the slow-network suspended-iteration scenario behind the fleet-wide native GPF crash loop we've been chasing on a production cluster: the renewing cursor stays bound to the read txn while the snapshot's pages become reclaimable, instead of releasing the snapshot.

## Change

- Factor #357's release logic into `Txn.prototype.releaseToRenewingCursors()` — close the renewing cursors (required before abort, or it can segfault), then `abort()`, releasing the snapshot.
- Call it from **both** `Txn.done` (the #357 path, behavior unchanged) and the **new** `resetReadTxn` branch (`renewingRefCount > 0 && !isDone`).
- Suspended iterators re-acquire on the current read txn via the existing `renewId` / `txn.isDone` reposition path in the range iterator's `next()`.
- Healthy synchronous scans never reach this branch, so there is **no hot-path cost**.

## Testing

- New regression test for the reset-in-place path: a renewing iterator suspended across a `resetReadTxn` tick (no other ref), then mutate + flush to make the old snapshot's pages reclaimable; the iterator must reposition and still read every key.
- Existing #357 sibling test (now routed through the shared helper) passes.
- Full `test/index.test.js`: **369 passing, 0 failing**, including the read-only-threads suite that hammers renewing read txns.

## Review notes

Cross-model review was run; the outside-model legs were unavailable this session (Codex CLI not installed; Gemini/`agy` timed out), so coverage was an independent adversarial Claude pass that traced both the JS and the native C++ (`txn.cpp`/`env.cpp`/`cursor.cpp`). No blockers or significant concerns. The one subtle path it confirmed: after the abort, `readTxn` is nulled, so the next read constructs a fresh `Txn` whose native ctor overwrites `currentReadTxn` before any pooled-cursor (`db.availableCursor`) reuse runs — the dangling-txn window is always closed before reuse.

## Honest caveat

This is the *proven-safe symmetric twin* of the deployed #357 fix. Static analysis could not conclusively prove that the reset-in-place branch is **the** residual `…50f` libc GPF on the affected cluster (every release path bumps `renewId` or sets `isDone`, which the reposition guard honors). It hardens the one path #357 left asymmetric, at negligible cost, and is worth deploying alongside live capture of the stranded-reader signature (`refCount`/`renewingRefCount`/`notCurrent`) to confirm root cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)