### PR TITLE
build: improve robustness of environment variable handling in binding.gyp

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -14,16 +14,16 @@
   "conditions": [
     ['OS=="win"', {
       "variables": {
-        "enable_fast_api_calls%": "<!(echo %ENABLE_FAST_API_CALLS%)",
-        "enable_v8%": "<!(echo %ENABLE_V8_FUNCTIONS%)",
-        "use_data_v1%": "<!(echo %LMDB_DATA_V1%)",
+        "enable_fast_api_calls%": "<!(node -p \"process.env.ENABLE_FAST_API_CALLS || 'true'\")",
+        "enable_v8%": "<!(node -p \"process.env.ENABLE_V8_FUNCTIONS || 'true'\")",
+        "use_data_v1%": "<!(node -p \"process.env.LMDB_DATA_V1 || 'false'\")",
       }
     }],
     ['OS!="win"', {
       "variables": {
-        "enable_fast_api_calls%": "<!(echo $ENABLE_FAST_API_CALLS)",
-        "enable_v8%": "<!(echo $ENABLE_V8_FUNCTIONS)",
-        "use_data_v1%": "<!(echo $LMDB_DATA_V1)",
+        "enable_fast_api_calls%": "<!(node -p \"process.env.ENABLE_FAST_API_CALLS || 'true'\")",
+        "enable_v8%": "<!(node -p \"process.env.ENABLE_V8_FUNCTIONS || 'true'\")",
+        "use_data_v1%": "<!(node -p \"process.env.LMDB_DATA_V1 || 'false'\")",
       }
     }]
   ],


### PR DESCRIPTION
Replaces platform-specific environment variable expansion (echo %VAR% / echo $VAR) in binding.gyp with cross-platform Node.js execution. This ensures consistent and robust configuration across Windows, Linux, and macOS environments, eliminating potential build issues caused by shell-specific formatting or trailing characters in environment variables. The configuration continues to respect the same default values and environment variable overrides as before, but does so in a more reliable and portable manner.